### PR TITLE
fix 最適解を作成するロジックを変更

### DIFF
--- a/src/aco_main_csv_networkx.py
+++ b/src/aco_main_csv_networkx.py
@@ -160,7 +160,7 @@ def update_pheromone(ant: Ant, graph: nx.Graph) -> None:
         u, v = ant.route[i - 1], ant.route[i]
         # pheromone_increase = min(ant.width) ** 2
         pheromone_increase = math.exp(min(ant.width) / 10)
-        # pheromone_increase = min(ant.width)
+        pheromone_increase = min(ant.width) * 10
         # u→v のフェロモンを更新（通った方向のみ）
         graph[u][v]["pheromone"] = min(
             graph[u][v]["pheromone"] + pheromone_increase, graph[u][v]["max_pheromone"]


### PR DESCRIPTION
最適解を作成するロジックが，「必ず4ホップで最適解」を作成してしまっていた．
ランダム性を持たせる関数と，ホップ数を指定して生成できる関数を追加した．

ランダム性では，ホップ数2からスタートし，ゴールに辿りつかないたびにホップ数を増やして，探索し，ゴールに辿り着いたらその経路を最適解とする帯域幅で書き換える．
あまりいい結果とはならなくなってしまった．

<img width="988" alt="image" src="https://github.com/user-attachments/assets/5bc3565f-c6a6-4588-a818-0cc5b48bc58a" />

[run simuration](https://github.com/TakumiSenaha/Ant-Colony-Optimization/pull/17/commits/07bea69057b1dfe1cd44af2520034308e1587309) 時点での結果

[log_ant.csv](https://github.com/user-attachments/files/18554209/log_ant.csv)

